### PR TITLE
Recommended install location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ BSMN common data processing pipeline
 This pipeline can be run in any cluster system using SGE job scheduler. I would recommend set your own cluster in AWS using AWS ParallelCluster.
 
 ## AWS ParallelCluster
-For installoing and setting up parallelcluster, plase see the [`Getting Started Guide`](https://aws-parallelcluster.readthedocs.io/en/latest/getting_started.html) for AWS ParallelCluster.
+For installoing and setting up parallelcluster, please see the [`Getting Started Guide`](https://aws-parallelcluster.readthedocs.io/en/latest/getting_started.html) for AWS ParallelCluster.
 
 ## Installing pipeline
-Check out bsmn_pipeline where you want it installed in the AWS Parallelcluster you set up or the cluster system you are using.
+Clone bsmn_pipeline where you want it installed in your cluster.  For example, if you work with an m5.large type AWS EC2 instance we recommend the file systems mounted at `/shared` or `/efs`.
 ```
+$ cd /shared
 $ git clone https://github.com/bsmn/bsmn_pipeline
 ```
 


### PR DESCRIPTION
First I installed bsmn-pipeline under /home/$USER, which is on a 15 Gb filesystem on m5.large type AWS EC2.  This was too small for bsmn-pipeline (including resources).  I am installing it now under both /shared (40 Gb) and /efs (8 Eb).  If /shared is the recommended location it is not documented currently so I updated README.md with this info.
